### PR TITLE
Not operator overload for SortOptions

### DIFF
--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -83,23 +83,15 @@ fn test_overloaded_not_sort_options() {
         },
     ];
 
-    // asserts true ( = !false)
     assert!((!sort_options_array[0]).descending);
-    // asserts true ( = !false)
     assert!((!sort_options_array[0]).nulls_first);
 
-    // asserts true ( = !false)
     assert!((!sort_options_array[1]).descending);
-    // asserts false ( = !true)
     assert!(!(!sort_options_array[1]).nulls_first);
 
-    // asserts false ( = !true)
     assert!(!(!sort_options_array[2]).descending);
-    // asserts true ( = !false)
     assert!((!sort_options_array[2]).nulls_first);
 
-    // asserts false ( = !true)
     assert!(!(!sort_options_array[3]).descending);
-    // asserts false ( = !true)
     assert!(!(!sort_options_array[3]).nulls_first);
 }

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -25,6 +25,7 @@ mod field;
 pub use field::*;
 mod schema;
 pub use schema::*;
+use std::ops;
 
 #[cfg(feature = "ffi")]
 pub mod ffi;
@@ -46,4 +47,48 @@ impl Default for SortOptions {
             nulls_first: true,
         }
     }
+}
+
+/// `!` operator is overloaded for `SortOptions` to invert boolean
+/// fields of the struct.
+impl ops::Not for SortOptions {
+    type Output = SortOptions;
+
+    fn not(self) -> SortOptions {
+        SortOptions {
+            descending: !self.descending,
+            nulls_first: !self.nulls_first,
+        }
+    }
+}
+
+#[test]
+fn test_overloaded_not_sort_options() {
+    let sort_options_array = [
+        SortOptions {
+            descending: false,
+            nulls_first: false,
+        },
+        SortOptions {
+            descending: false,
+            nulls_first: true,
+        },
+        SortOptions {
+            descending: true,
+            nulls_first: false,
+        },
+        SortOptions {
+            descending: true,
+            nulls_first: true,
+        },
+    ];
+
+    assert_eq!(!sort_options_array[0].descending, true);
+    assert_eq!(!sort_options_array[0].nulls_first, true);
+    assert_eq!(!sort_options_array[1].descending, true);
+    assert_eq!(!sort_options_array[1].nulls_first, false);
+    assert_eq!(!sort_options_array[2].descending, false);
+    assert_eq!(!sort_options_array[2].nulls_first, true);
+    assert_eq!(!sort_options_array[3].descending, false);
+    assert_eq!(!sort_options_array[3].nulls_first, false);
 }

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -30,7 +30,7 @@ pub use schema::*;
 pub mod ffi;
 
 /// Options that define the sort order of a given column
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SortOptions {
     /// Whether to sort in descending order
     pub descending: bool,

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -83,12 +83,23 @@ fn test_overloaded_not_sort_options() {
         },
     ];
 
-    assert_eq!(!sort_options_array[0].descending, true);
-    assert_eq!(!sort_options_array[0].nulls_first, true);
-    assert_eq!(!sort_options_array[1].descending, true);
-    assert_eq!(!sort_options_array[1].nulls_first, false);
-    assert_eq!(!sort_options_array[2].descending, false);
-    assert_eq!(!sort_options_array[2].nulls_first, true);
-    assert_eq!(!sort_options_array[3].descending, false);
-    assert_eq!(!sort_options_array[3].nulls_first, false);
+    // asserts true ( = !false)
+    assert!((!sort_options_array[0]).descending);
+    // asserts true ( = !false)
+    assert!((!sort_options_array[0]).nulls_first);
+
+    // asserts true ( = !false)
+    assert!((!sort_options_array[1]).descending);
+    // asserts false ( = !true)
+    assert!(!(!sort_options_array[1]).nulls_first);
+
+    // asserts false ( = !true)
+    assert!(!(!sort_options_array[2]).descending);
+    // asserts true ( = !false)
+    assert!((!sort_options_array[2]).nulls_first);
+
+    // asserts false ( = !true)
+    assert!(!(!sort_options_array[3]).descending);
+    // asserts false ( = !true)
+    assert!(!(!sort_options_array[3]).nulls_first);
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3726.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`!` operator can be used for `SortOptions` type to take reverse sort.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`!` operator is overloaded for `SortOptions` to invert boolean fields of the struct.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

No.
