### PR TITLE
Async CSV writer in arrow-csv

### DIFF
--- a/arrow-csv/Cargo.toml
+++ b/arrow-csv/Cargo.toml
@@ -45,6 +45,8 @@ arrow-data = { version = "33.0.0", path = "../arrow-data" }
 arrow-schema = { version = "33.0.0", path = "../arrow-schema" }
 chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 csv = { version = "1.1", default-features = false }
+csv-async = {version = "1.2.5", features = ["tokio"]}
+tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "fs"] }
 csv-core = { version = "0.1"}
 lazy_static = { version = "1.4", default-features = false }
 lexical-core = { version = "^0.8", default-features = false }
@@ -52,3 +54,5 @@ regex = { version = "1.7.0", default-features = false, features = ["std", "unico
 
 [dev-dependencies]
 tempfile = "3.3"
+async-tempfile = "0.2.0"
+futures = { version = "0.3", default-features = false, features = ["std"] }

--- a/arrow-csv/src/lib.rs
+++ b/arrow-csv/src/lib.rs
@@ -23,10 +23,10 @@ pub mod writers;
 pub use self::reader::infer_schema_from_files;
 pub use self::reader::Reader;
 pub use self::reader::ReaderBuilder;
-pub use self::writers::AsyncWriter;
-pub use self::writers::AsyncWriterBuilder;
-pub use self::writers::Writer;
-pub use self::writers::WriterBuilder;
+pub use self::writers::async_writer::AsyncWriter;
+pub use self::writers::async_writer::AsyncWriterBuilder;
+pub use self::writers::writer::Writer;
+pub use self::writers::writer::WriterBuilder;
 use arrow_schema::ArrowError;
 
 fn map_csv_error(error: csv::Error) -> ArrowError {

--- a/arrow-csv/src/writers/async_writer.rs
+++ b/arrow-csv/src/writers/async_writer.rs
@@ -1,3 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Async CSV Writer
+//!
+//! This CSV writer allows Arrow data (in record batches) to be written as CSV files leveraging
+//! tokio::AsyncWrite trait.
+//! The writer does not support writing `ListArray` and `StructArray`.
+//!
+
 use crate::map_async_csv_error;
 use crate::writers::{
     get_converters, get_header, DEFAULT_DATE_FORMAT, DEFAULT_NULL_VALUE,
@@ -9,7 +33,7 @@ use arrow_schema::ArrowError;
 use csv_async::ByteRecord;
 use tokio::io::AsyncWrite;
 
-/// A CSV writer
+/// A Async CSV writer
 #[derive(Debug)]
 pub struct AsyncWriter<W: AsyncWrite + Unpin + Send> {
     /// The object to write to
@@ -144,7 +168,7 @@ impl Default for AsyncWriterBuilder {
 impl AsyncWriterBuilder {
     /// Create a new builder for configuring CSV writing options.
     ///
-    /// To convert a builder into a writer, call `WriterBuilder::build`
+    /// To convert a builder into a writer, call `AsyncWriterBuilder::build`
     ///
     /// # Example
     ///

--- a/arrow-csv/src/writers/async_writer.rs
+++ b/arrow-csv/src/writers/async_writer.rs
@@ -1,0 +1,401 @@
+use crate::map_async_csv_error;
+use crate::writers::{
+    get_converters, get_header, DEFAULT_DATE_FORMAT, DEFAULT_NULL_VALUE,
+    DEFAULT_TIMESTAMP_FORMAT, DEFAULT_TIMESTAMP_TZ_FORMAT, DEFAULT_TIME_FORMAT,
+};
+use arrow_array::RecordBatch;
+use arrow_cast::display::FormatOptions;
+use arrow_schema::ArrowError;
+use csv_async::ByteRecord;
+use tokio::io::AsyncWrite;
+
+/// A CSV writer
+#[derive(Debug)]
+pub struct AsyncWriter<W: AsyncWrite + Unpin + Send> {
+    /// The object to write to
+    writer: csv_async::AsyncWriter<W>,
+    /// Whether file should be written with headers. Defaults to `true`
+    has_headers: bool,
+    /// The date format for date arrays
+    date_format: Option<String>,
+    /// The datetime format for datetime arrays
+    datetime_format: Option<String>,
+    /// The timestamp format for timestamp arrays
+    timestamp_format: Option<String>,
+    /// The timestamp format for timestamp (with timezone) arrays
+    timestamp_tz_format: Option<String>,
+    /// The time format for time arrays
+    time_format: Option<String>,
+    /// Is the beginning-of-writer
+    beginning: bool,
+    /// The value to represent null entries
+    null_value: String,
+}
+
+impl<W: AsyncWrite + Unpin + Send> AsyncWriter<W> {
+    /// Create a new CsvWriter from a writable object, with default options
+    pub fn new(writer: W) -> Self {
+        let delimiter = b',';
+        let writer = csv_async::AsyncWriterBuilder::new()
+            .delimiter(delimiter)
+            .create_writer(writer);
+        AsyncWriter {
+            writer,
+            has_headers: true,
+            date_format: Some(DEFAULT_DATE_FORMAT.to_string()),
+            datetime_format: Some(DEFAULT_TIMESTAMP_FORMAT.to_string()),
+            time_format: Some(DEFAULT_TIME_FORMAT.to_string()),
+            timestamp_format: Some(DEFAULT_TIMESTAMP_FORMAT.to_string()),
+            timestamp_tz_format: Some(DEFAULT_TIMESTAMP_TZ_FORMAT.to_string()),
+            beginning: true,
+            null_value: DEFAULT_NULL_VALUE.to_string(),
+        }
+    }
+
+    /// Write a record batches to a writable object
+    pub async fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
+        if self.beginning {
+            if self.has_headers {
+                let headers = get_header(batch);
+                self.writer
+                    .write_record(&headers[..])
+                    .await
+                    .map_err(map_async_csv_error)?;
+            }
+            self.beginning = false;
+        }
+
+        let options = FormatOptions::default()
+            .with_null(&self.null_value)
+            .with_date_format(self.date_format.as_deref())
+            .with_datetime_format(self.datetime_format.as_deref())
+            .with_timestamp_format(self.timestamp_format.as_deref())
+            .with_timestamp_tz_format(self.timestamp_tz_format.as_deref())
+            .with_time_format(self.time_format.as_deref());
+
+        let converters = get_converters(batch, &options)?;
+
+        let mut buffer = String::with_capacity(1024);
+        let mut byte_record = ByteRecord::with_capacity(1024, converters.len());
+
+        for row_idx in 0..batch.num_rows() {
+            byte_record.clear();
+            for (col_idx, converter) in converters.iter().enumerate() {
+                buffer.clear();
+                converter.value(row_idx).write(&mut buffer).map_err(|e| {
+                    ArrowError::CsvError(format!(
+                        "Error formatting row {} and column {}: {e}",
+                        row_idx + 1,
+                        col_idx + 1
+                    ))
+                })?;
+                byte_record.push_field(buffer.as_bytes());
+            }
+            self.writer
+                .write_byte_record(&byte_record)
+                .await
+                .map_err(map_async_csv_error)?;
+        }
+        self.writer.flush().await?;
+
+        Ok(())
+    }
+}
+
+/// A CSV writer builder
+#[derive(Debug)]
+pub struct AsyncWriterBuilder {
+    /// Optional column delimiter. Defaults to `b','`
+    delimiter: Option<u8>,
+    /// Whether to write column names as file headers. Defaults to `true`
+    has_headers: bool,
+    /// Whether to start from beginning.
+    beginning: bool,
+    /// Optional date format for date arrays
+    date_format: Option<String>,
+    /// Optional datetime format for datetime arrays
+    datetime_format: Option<String>,
+    /// Optional timestamp format for timestamp arrays
+    timestamp_format: Option<String>,
+    /// Optional timestamp format for timestamp with timezone arrays
+    timestamp_tz_format: Option<String>,
+    /// Optional time format for time arrays
+    time_format: Option<String>,
+    /// Optional value to represent null
+    null_value: Option<String>,
+}
+
+impl Default for AsyncWriterBuilder {
+    fn default() -> Self {
+        Self {
+            has_headers: true,
+            beginning: true,
+            delimiter: None,
+            date_format: Some(DEFAULT_DATE_FORMAT.to_string()),
+            datetime_format: Some(DEFAULT_TIMESTAMP_FORMAT.to_string()),
+            time_format: Some(DEFAULT_TIME_FORMAT.to_string()),
+            timestamp_format: Some(DEFAULT_TIMESTAMP_FORMAT.to_string()),
+            timestamp_tz_format: Some(DEFAULT_TIMESTAMP_TZ_FORMAT.to_string()),
+            null_value: Some(DEFAULT_NULL_VALUE.to_string()),
+        }
+    }
+}
+
+impl AsyncWriterBuilder {
+    /// Create a new builder for configuring CSV writing options.
+    ///
+    /// To convert a builder into a writer, call `WriterBuilder::build`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use arrow_csv::{AsyncWriter, AsyncWriterBuilder};
+    /// # use tokio::fs::File;
+    ///
+    /// async fn example() -> AsyncWriter<File> {
+    ///     let file = File::create("target/out.csv").await.unwrap();
+    ///
+    ///     // create a builder that doesn't write headers
+    ///     let builder = AsyncWriterBuilder::new().has_headers(false).with_delimiter(b'|');
+    ///     let writer = builder.build(file);
+    ///
+    ///     writer
+    /// }
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set whether to write headers
+    pub fn has_headers(mut self, has_headers: bool) -> Self {
+        self.has_headers = has_headers;
+        self
+    }
+
+    /// Set the CSV file's column delimiter as a byte character
+    pub fn with_delimiter(mut self, delimiter: u8) -> Self {
+        self.delimiter = Some(delimiter);
+        self
+    }
+
+    /// Set the CSV file's date format
+    pub fn with_date_format(mut self, format: String) -> Self {
+        self.date_format = Some(format);
+        self
+    }
+
+    /// Set the CSV file's datetime format
+    pub fn with_datetime_format(mut self, format: String) -> Self {
+        self.datetime_format = Some(format);
+        self
+    }
+
+    /// Set the CSV file's time format
+    pub fn with_time_format(mut self, format: String) -> Self {
+        self.time_format = Some(format);
+        self
+    }
+
+    /// Set the CSV file's timestamp format
+    pub fn with_timestamp_format(mut self, format: String) -> Self {
+        self.timestamp_format = Some(format);
+        self
+    }
+
+    /// Set the value to represent null in output
+    pub fn with_null(mut self, null_value: String) -> Self {
+        self.null_value = Some(null_value);
+        self
+    }
+
+    /// Use RFC3339 format for date/time/timestamps
+    pub fn with_rfc3339(mut self) -> Self {
+        self.date_format = None;
+        self.datetime_format = None;
+        self.time_format = None;
+        self.timestamp_format = None;
+        self.timestamp_tz_format = None;
+        self
+    }
+
+    /// Create a new `Writer`
+    pub fn build<W: AsyncWrite + Unpin + Send>(self, writer: W) -> AsyncWriter<W> {
+        let writer = csv_async::AsyncWriterBuilder::new()
+            .delimiter(self.delimiter.unwrap_or(b','))
+            .create_writer(writer);
+        AsyncWriter {
+            writer,
+            has_headers: self.has_headers,
+            date_format: self.date_format,
+            datetime_format: self.datetime_format,
+            time_format: self.time_format,
+            timestamp_format: self.timestamp_format,
+            timestamp_tz_format: self.timestamp_tz_format,
+            beginning: self.beginning,
+            null_value: self
+                .null_value
+                .unwrap_or_else(|| DEFAULT_NULL_VALUE.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, SeekFrom};
+
+    use crate::writers::test_utils::{
+        test_conversion_consistency_case, test_write_csv_case,
+        test_write_csv_custom_options_case, test_write_csv_decimal_case,
+        test_write_csv_using_rfc3339_case,
+    };
+    use arrow_array::{Date32Array, Date64Array, TimestampNanosecondArray, UInt32Array};
+    use arrow_schema::{DataType, Field, Schema, TimeUnit};
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    #[tokio::test]
+    async fn test_writer() -> Result<(), ArrowError> {
+        let (batches, expected) = test_write_csv_case()?;
+
+        let mut file = async_tempfile::TempFile::new().await.unwrap();
+
+        let mut writer = AsyncWriter::new(&mut file);
+        for batch in batches {
+            writer.write(&batch).await?;
+        }
+        drop(writer);
+
+        // check that file was written successfully
+        file.seek(SeekFrom::Start(0)).await?;
+        let mut buffer: Vec<u8> = vec![];
+        file.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(expected, String::from_utf8(buffer).unwrap());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_write_csv_decimal() -> Result<(), ArrowError> {
+        let (batches, expected) = test_write_csv_decimal_case()?;
+
+        let mut file = async_tempfile::TempFile::new().await.unwrap();
+
+        let mut writer = AsyncWriter::new(&mut file);
+        for batch in batches {
+            writer.write(&batch).await?;
+        }
+        drop(writer);
+
+        // check that file was written successfully
+        file.seek(SeekFrom::Start(0)).await?;
+        let mut buffer: Vec<u8> = vec![];
+        file.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(expected, String::from_utf8(buffer).unwrap());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_write_csv_custom_options() -> Result<(), ArrowError> {
+        let (batches, expected) = test_write_csv_custom_options_case()?;
+
+        let mut file = async_tempfile::TempFile::new().await.unwrap();
+
+        let builder = AsyncWriterBuilder::new()
+            .has_headers(false)
+            .with_delimiter(b'|')
+            .with_null("NULL".to_string())
+            .with_time_format("%r".to_string());
+        let mut writer = builder.build(&mut file);
+        for batch in batches {
+            writer.write(&batch).await?;
+        }
+        drop(writer);
+
+        // check that file was written successfully
+        file.seek(SeekFrom::Start(0)).await?;
+        let mut buffer: Vec<u8> = vec![];
+        file.read_to_end(&mut buffer).await.unwrap();
+        assert_eq!(expected, String::from_utf8(buffer).unwrap());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_write_csv_invalid_cast() {
+        let schema = Schema::new(vec![
+            Field::new("c0", DataType::UInt32, false),
+            Field::new("c1", DataType::Date64, false),
+        ]);
+
+        let c0 = UInt32Array::from(vec![Some(123), Some(234)]);
+        let c1 = Date64Array::from(vec![Some(1926632005177), Some(1926632005177685347)]);
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(c0), Arc::new(c1)])
+                .unwrap();
+
+        let mut file = async_tempfile::TempFile::new().await.unwrap();
+        let mut writer = AsyncWriter::new(&mut file);
+        let batches = vec![&batch, &batch];
+        for batch in batches {
+            let err = writer.write(batch).await.unwrap_err().to_string();
+            assert_eq!(err, "Csv error: Error formatting row 2 and column 2: Cast error: Failed to convert 1926632005177685347 to temporal for Date64")
+        }
+        drop(writer);
+    }
+
+    #[tokio::test]
+    async fn test_conversion_consistency() -> Result<(), ArrowError> {
+        // test if we can serialize and deserialize whilst retaining the same type information/ precision
+        let schema = Schema::new(vec![
+            Field::new("c1", DataType::Date32, false),
+            Field::new("c2", DataType::Date64, false),
+            Field::new("c3", DataType::Timestamp(TimeUnit::Nanosecond, None), false),
+        ]);
+
+        let nanoseconds = vec![
+            1599566300000000000,
+            1599566200000000000,
+            1599566100000000000,
+        ];
+        let c1 = Date32Array::from(vec![3, 2, 1]);
+        let c2 = Date64Array::from(vec![3, 2, 1]);
+        let c3 = TimestampNanosecondArray::from(nanoseconds.clone());
+
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(c1), Arc::new(c2), Arc::new(c3)],
+        )?;
+
+        let builder = AsyncWriterBuilder::new().has_headers(false);
+
+        let mut buf: Cursor<Vec<u8>> = Default::default();
+        // drop the writer early to release the borrow.
+        {
+            let mut writer = builder.build(&mut buf);
+            writer.write(&batch).await?;
+        }
+        buf.set_position(0);
+        test_conversion_consistency_case(&mut buf, Arc::new(schema), nanoseconds)?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_write_csv_using_rfc3339() -> Result<(), ArrowError> {
+        let (batches, expected) = test_write_csv_using_rfc3339_case()?;
+
+        let mut file = async_tempfile::TempFile::new().await.unwrap();
+
+        let builder = AsyncWriterBuilder::new().with_rfc3339();
+        let mut writer = builder.build(&mut file);
+        for batch in batches {
+            writer.write(&batch).await?;
+        }
+        drop(writer);
+
+        file.seek(SeekFrom::Start(0)).await?;
+        let mut buffer: Vec<u8> = vec![];
+        file.read_to_end(&mut buffer).await?;
+
+        assert_eq!(expected, String::from_utf8(buffer).unwrap());
+        Ok(())
+    }
+}

--- a/arrow-csv/src/writers/mod.rs
+++ b/arrow-csv/src/writers/mod.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-mod async_writer;
+pub mod async_writer;
 #[cfg(test)]
 mod test_utils;
-mod writer;
+pub mod writer;
 
 use arrow_array::RecordBatch;
 use arrow_cast::display::{ArrayFormatter, FormatOptions};

--- a/arrow-csv/src/writers/mod.rs
+++ b/arrow-csv/src/writers/mod.rs
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod async_writer;
+#[cfg(test)]
+mod test_utils;
+mod writer;
+
+use arrow_array::RecordBatch;
+use arrow_cast::display::{ArrayFormatter, FormatOptions};
+use arrow_schema::{ArrowError, DataType};
+pub use async_writer::AsyncWriter;
+pub use async_writer::AsyncWriterBuilder;
+pub use writer::Writer;
+pub use writer::WriterBuilder;
+
+pub const DEFAULT_DATE_FORMAT: &str = "%F";
+pub const DEFAULT_TIME_FORMAT: &str = "%T";
+pub const DEFAULT_TIMESTAMP_FORMAT: &str = "%FT%H:%M:%S.%9f";
+pub const DEFAULT_TIMESTAMP_TZ_FORMAT: &str = "%FT%H:%M:%S.%9f%:z";
+pub const DEFAULT_NULL_VALUE: &str = "";
+
+pub fn get_header(batch: &RecordBatch) -> Vec<String> {
+    let mut headers: Vec<String> = Vec::with_capacity(batch.num_columns());
+    batch
+        .schema()
+        .fields()
+        .iter()
+        .for_each(|field| headers.push(field.name().to_string()));
+    headers
+}
+
+pub fn get_converters<'a>(
+    batch: &'a RecordBatch,
+    options: &'a FormatOptions<'a>,
+) -> Result<Vec<ArrayFormatter<'a>>, ArrowError> {
+    batch
+        .columns()
+        .iter()
+        .map(|a| match a.data_type() {
+            d if d.is_nested() => Err(ArrowError::CsvError(format!(
+                "Nested type {} is not supported in CSV",
+                a.data_type()
+            ))),
+            DataType::Binary | DataType::LargeBinary => Err(ArrowError::CsvError(
+                "Binary data cannot be written to CSV".to_string(),
+            )),
+            _ => ArrayFormatter::try_new(a.as_ref(), options),
+        })
+        .collect::<Result<Vec<_>, ArrowError>>()
+}

--- a/arrow-csv/src/writers/test_utils.rs
+++ b/arrow-csv/src/writers/test_utils.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Test utilities for sync and async writers.
+
 use crate::Reader;
 use arrow_array::builder::{Decimal128Builder, Decimal256Builder};
 use arrow_array::types::{Float64Type, Int32Type, UInt32Type};

--- a/arrow-csv/src/writers/test_utils.rs
+++ b/arrow-csv/src/writers/test_utils.rs
@@ -1,0 +1,230 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::Reader;
+use arrow_array::builder::{Decimal128Builder, Decimal256Builder};
+use arrow_array::types::{Float64Type, Int32Type, UInt32Type};
+use arrow_array::{
+    BooleanArray, Date32Array, Date64Array, DictionaryArray, PrimitiveArray, RecordBatch,
+    StringArray, Time32SecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+};
+use arrow_buffer::i256;
+use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef, TimeUnit};
+use std::io::Cursor;
+use std::sync::Arc;
+
+pub(crate) fn test_write_csv_case() -> Result<(Vec<RecordBatch>, String), ArrowError> {
+    let schema = Schema::new(vec![
+        Field::new("c1", DataType::Utf8, false),
+        Field::new("c2", DataType::Float64, true),
+        Field::new("c3", DataType::UInt32, false),
+        Field::new("c4", DataType::Boolean, true),
+        Field::new("c5", DataType::Timestamp(TimeUnit::Millisecond, None), true),
+        Field::new("c6", DataType::Time32(TimeUnit::Second), false),
+        Field::new(
+            "c7",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            false,
+        ),
+    ]);
+
+    let c1 = StringArray::from(vec![
+        "Lorem ipsum dolor sit amet",
+        "consectetur adipiscing elit",
+        "sed do eiusmod tempor",
+    ]);
+    let c2 = PrimitiveArray::<Float64Type>::from(vec![
+        Some(123.564532),
+        None,
+        Some(-556132.25),
+    ]);
+    let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
+    let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
+    let c5 = TimestampMillisecondArray::from(vec![
+        None,
+        Some(1555584887378),
+        Some(1555555555555),
+    ]);
+    let c6 = Time32SecondArray::from(vec![1234, 24680, 85563]);
+    let c7: DictionaryArray<Int32Type> =
+        vec!["cupcakes", "cupcakes", "foo"].into_iter().collect();
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(c1),
+            Arc::new(c2),
+            Arc::new(c3),
+            Arc::new(c4),
+            Arc::new(c5),
+            Arc::new(c6),
+            Arc::new(c7),
+        ],
+    )?;
+
+    let expected = r#"c1,c2,c3,c4,c5,c6,c7
+Lorem ipsum dolor sit amet,123.564532,3,true,,00:20:34,cupcakes
+consectetur adipiscing elit,,2,false,2019-04-18T10:54:47.378000000,06:51:20,cupcakes
+sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03,foo
+Lorem ipsum dolor sit amet,123.564532,3,true,,00:20:34,cupcakes
+consectetur adipiscing elit,,2,false,2019-04-18T10:54:47.378000000,06:51:20,cupcakes
+sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03,foo
+"#
+    .to_owned();
+
+    Ok((vec![batch.clone(), batch.clone()], expected))
+}
+
+pub(crate) fn test_write_csv_decimal_case(
+) -> Result<(Vec<RecordBatch>, String), ArrowError> {
+    let schema = Schema::new(vec![
+        Field::new("c1", DataType::Decimal128(38, 6), true),
+        Field::new("c2", DataType::Decimal256(76, 6), true),
+    ]);
+
+    let mut c1_builder =
+        Decimal128Builder::new().with_data_type(DataType::Decimal128(38, 6));
+    c1_builder.extend(vec![Some(-3335724), Some(2179404), None, Some(290472)]);
+    let c1 = c1_builder.finish();
+
+    let mut c2_builder =
+        Decimal256Builder::new().with_data_type(DataType::Decimal256(76, 6));
+    c2_builder.extend(vec![
+        Some(i256::from_i128(-3335724)),
+        Some(i256::from_i128(2179404)),
+        None,
+        Some(i256::from_i128(290472)),
+    ]);
+    let c2 = c2_builder.finish();
+
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(c1), Arc::new(c2)])?;
+    let batches = vec![batch.clone(), batch];
+    let expected = r#"c1,c2
+-3.335724,-3.335724
+2.179404,2.179404
+,
+0.290472,0.290472
+-3.335724,-3.335724
+2.179404,2.179404
+,
+0.290472,0.290472
+"#
+    .to_owned();
+    Ok((batches, expected))
+}
+
+pub(crate) fn test_write_csv_custom_options_case(
+) -> Result<(Vec<RecordBatch>, String), ArrowError> {
+    let schema = Schema::new(vec![
+        Field::new("c1", DataType::Utf8, false),
+        Field::new("c2", DataType::Float64, true),
+        Field::new("c3", DataType::UInt32, false),
+        Field::new("c4", DataType::Boolean, true),
+        Field::new("c6", DataType::Time32(TimeUnit::Second), false),
+    ]);
+
+    let c1 = StringArray::from(vec![
+        "Lorem ipsum dolor sit amet",
+        "consectetur adipiscing elit",
+        "sed do eiusmod tempor",
+    ]);
+    let c2 = PrimitiveArray::<Float64Type>::from(vec![
+        Some(123.564532),
+        None,
+        Some(-556132.25),
+    ]);
+    let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
+    let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
+    let c6 = Time32SecondArray::from(vec![1234, 24680, 85563]);
+
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(c1),
+            Arc::new(c2),
+            Arc::new(c3),
+            Arc::new(c4),
+            Arc::new(c6),
+        ],
+    )?;
+    let batches = vec![batch];
+    let expected = "Lorem ipsum dolor sit amet|123.564532|3|true|12:20:34 AM\nconsectetur adipiscing elit|NULL|2|false|06:51:20 AM\nsed do eiusmod tempor|-556132.25|1|NULL|11:46:03 PM\n".to_owned();
+    Ok((batches, expected))
+}
+
+pub(crate) fn test_write_csv_using_rfc3339_case(
+) -> Result<(Vec<RecordBatch>, String), ArrowError> {
+    let schema = Schema::new(vec![
+        Field::new(
+            "c1",
+            DataType::Timestamp(TimeUnit::Millisecond, Some("+00:00".to_string())),
+            true,
+        ),
+        Field::new("c2", DataType::Timestamp(TimeUnit::Millisecond, None), true),
+        Field::new("c3", DataType::Date32, false),
+        Field::new("c4", DataType::Time32(TimeUnit::Second), false),
+    ]);
+
+    let c1 =
+        TimestampMillisecondArray::from(vec![Some(1555584887378), Some(1635577147000)])
+            .with_timezone("+00:00".to_string());
+    let c2 =
+        TimestampMillisecondArray::from(vec![Some(1555584887378), Some(1635577147000)]);
+    let c3 = Date32Array::from(vec![3, 2]);
+    let c4 = Time32SecondArray::from(vec![1234, 24680]);
+
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(c1), Arc::new(c2), Arc::new(c3), Arc::new(c4)],
+    )?;
+    let batches = vec![batch];
+    let expected = "c1,c2,c3,c4
+2019-04-18T10:54:47.378Z,2019-04-18T10:54:47.378,1970-01-04,00:20:34
+2021-10-30T06:59:07Z,2021-10-30T06:59:07,1970-01-03,06:51:20\n"
+        .to_owned();
+    Ok((batches, expected))
+}
+
+pub(crate) fn test_conversion_consistency_case(
+    buf: &mut Cursor<Vec<u8>>,
+    schema: SchemaRef,
+    nanoseconds: Vec<i64>,
+) -> Result<(), ArrowError> {
+    // test if we can serialize and deserialize whilst retaining the same type information/ precision
+    let mut reader = Reader::new(
+        buf, schema, false, None, 3, // starting at row 2 and up to row 6.
+        None, None, None,
+    );
+    let rb = reader.next().unwrap().unwrap();
+    let c1 = rb.column(0).as_any().downcast_ref::<Date32Array>().unwrap();
+    let c2 = rb.column(1).as_any().downcast_ref::<Date64Array>().unwrap();
+    let c3 = rb
+        .column(2)
+        .as_any()
+        .downcast_ref::<TimestampNanosecondArray>()
+        .unwrap();
+
+    let actual = c1.into_iter().collect::<Vec<_>>();
+    let expected = vec![Some(3), Some(2), Some(1)];
+    assert_eq!(actual, expected);
+    let actual = c2.into_iter().collect::<Vec<_>>();
+    let expected = vec![Some(3), Some(2), Some(1)];
+    assert_eq!(actual, expected);
+    let actual = c3.into_iter().collect::<Vec<_>>();
+    let expected = nanoseconds.into_iter().map(Some).collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+    Ok(())
+}

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -37,7 +37,7 @@ itertools = "0.10.1"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 snafu = "0.7"
-tokio = { version = "1.18", features = ["sync", "macros", "rt", "time", "io-util"] }
+tokio = { version = "1.18", features = ["sync", "macros", "rt", "time", "io-util", "fs"] }
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -281,6 +281,10 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// Save the provided bytes to the specified location.
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()>;
 
+    async fn append(&self, location: &Path, bytes: &Bytes) -> Result<()>{
+        Ok(())
+    }
+
     /// Get a multi-part upload that allows writing data in chunks
     ///
     /// Most cloud-based uploads will buffer and upload parts in parallel.


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-rs-object-store/issues/188.

# Rationale for this change
For tokio runtimes, IO operations can be async and non-blocking. 

# What changes are included in this PR?

A new writer in `arrow-csv`.

# Are there any user-facing changes?
No
