### PR TITLE
Append API

### DIFF
--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -194,7 +194,7 @@ impl<W: Write> Writer<W> {
 }
 
 /// A CSV writer builder
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct WriterBuilder {
     /// Optional column delimiter. Defaults to `b','`
     delimiter: Option<u8>,

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -258,7 +258,7 @@ use crate::util::{coalesce_ranges, collect_bytes, OBJECT_STORE_COALESCE_DEFAULT}
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use futures::{stream::BoxStream, StreamExt};
+use futures::{stream::BoxStream, Stream, StreamExt};
 use snafu::Snafu;
 use std::fmt::{Debug, Formatter};
 #[cfg(not(target_arch = "wasm32"))]
@@ -280,6 +280,15 @@ pub type MultipartId = String;
 pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// Save the provided bytes to the specified location.
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()>;
+
+    /// Append the provided byte stream to the specified location.
+    async fn append(
+        &self,
+        _location: &Path,
+        _bytes: Box<dyn Stream<Item = Result<Bytes>> + Send + Unpin>,
+    ) -> Result<()> {
+        Err(Error::NotImplemented)
+    }
 
     /// Get a multi-part upload that allows writing data in chunks
     ///

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -285,7 +285,7 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     async fn append(
         &self,
         _location: &Path,
-        _bytes: Box<dyn Stream<Item = Result<Bytes>> + Send + Unpin>,
+        _bytes: Box<dyn Stream<Item = Bytes> + Send + Unpin>,
     ) -> Result<()> {
         Err(Error::NotImplemented)
     }

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -282,7 +282,7 @@ impl ObjectStore for LocalFileSystem {
     ) -> Result<()> {
         let path = self.config.path_to_filesystem(location)?;
         let mut options = OpenOptions::new();
-        options.write(true).truncate(true).create(true);
+        options.write(true).truncate(false).create(true);
         let mut file = open_writable_file(&path, &options)?;
         while let Some(chunk) = bytes.next().await {
             file = maybe_spawn_blocking(move || {


### PR DESCRIPTION
# Which issue does this PR close?

Solves the problem in https://github.com/apache/arrow-rs-object-store/issues/188 and https://github.com/apache/arrow-rs-object-store/issues/187 and contributes https://github.com/apache/arrow-datafusion/issues/5130

# Rationale for this change

Support for appending bytes into files with ByteStream in ObjectStore API. 

# What changes are included in this PR?

This PR adds support for appending bytes to files in the ObjectStore API using ByteStream. The changes included in this PR are:

- ObjectStore trait API support
- Implementation of Localfilesystem store.

In the future, we plan to implement ByteStream support for the following:

- Azure
- InMemory
- Http

# Are there any user-facing changes?

With this update, users can now use the **`append`** API to append files. There are no breaking changes to the API.